### PR TITLE
fix: fromMap should convert the map['price'] to num then double

### DIFF
--- a/lib/shared/models/product.dart
+++ b/lib/shared/models/product.dart
@@ -56,7 +56,7 @@ class Product {
         (e) => e.name == map['category'],
         orElse: () => ProductCategory.others,
       ),
-      price: map['price'],
+      price: (map['price'] as num).toDouble(),
     );
   }
 }


### PR DESCRIPTION
- made a small fix in the fromMap in Product model

Note: doesn't handle cases where map uses 'id' instead of 'productId'